### PR TITLE
feat: lazy load images

### DIFF
--- a/film_packaging/by_brand.md
+++ b/film_packaging/by_brand.md
@@ -110,7 +110,9 @@ UUID    : 14047842e1a641268bfd4d01fcf02c95
 Scanned By: dekuNukem
 ```
 
-[![ADOX KB17 35mm film_box_outside](./lowres/00065_000.jpg)](./archive/00065_000.jpg)
+<a href="./archive/00065_000.jpg">
+	<img src="./lowres/00065_000.jpg" alt="ADOX KB17 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for ADOX KB17 (ref: d3b7)](./archive/00065_001.jpg)
 
@@ -124,7 +126,9 @@ UUID    : a20bbca534454915a6970b6ede2212c7
 Scanned By: dekuNukem
 ```
 
-[![AGFA APX 120 film_box_outside](./lowres/00011_000.jpg)](./archive/00011_000.jpg)
+<a href="./archive/00011_000.jpg">
+	<img src="./lowres/00011_000.jpg" alt="AGFA APX 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for AGFA APX (ref: a8dd)](./archive/00011_001.jpg)
 
@@ -138,7 +142,9 @@ UUID    : d10e846ba5154f1d940ed7009a904faa
 Scanned By: dekuNukem
 ```
 
-[![AGFA ULTRA 50 35mm film_box_outside](./lowres/00010_000.jpg)](./archive/00010_000.jpg)
+<a href="./archive/00010_000.jpg">
+	<img src="./lowres/00010_000.jpg" alt="AGFA ULTRA 50 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for AGFA ULTRA 50 (ref: 8fc0)](./archive/00010_001.jpg)
 
@@ -152,7 +158,9 @@ UUID    : f1e50745927f4b7cb16af36fd30dd3af
 Scanned By: dekuNukem
 ```
 
-[![AGFA Vista 35mm film_box_outside](./lowres/00014_000.jpg)](./archive/00014_000.jpg)
+<a href="./archive/00014_000.jpg">
+	<img src="./lowres/00014_000.jpg" alt="AGFA Vista 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for AGFA Vista (ref: cd56)](./archive/00014_001.jpg)
 
@@ -166,7 +174,9 @@ UUID    : aedc4b00bd174e0baf7c744ed21d8820
 Scanned By: dekuNukem
 ```
 
-[![Alien Film 5207/250D 120 film_box_outside](./lowres/00001_000.jpg)](./archive/00001_000.jpg)
+<a href="./archive/00001_000.jpg">
+	<img src="./lowres/00001_000.jpg" alt="Alien Film 5207/250D 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Alien Film 5222/XX (ref: 3e49)
 ```
@@ -178,7 +188,9 @@ UUID    : 9984ed6c13cd4be496e7e4b58e313e49
 Scanned By: dekuNukem
 ```
 
-[![Alien Film 5222/XX 35mm film_box_outside](./lowres/00057_000.jpg)](./archive/00057_000.jpg)
+<a href="./archive/00057_000.jpg">
+	<img src="./lowres/00057_000.jpg" alt="Alien Film 5222/XX 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### CineStill 800T (ref: c86a)
 ```
@@ -190,7 +202,9 @@ UUID    : 53253eca96d841f5b98bfb3590fec86a
 Scanned By: dekuNukem
 ```
 
-[![CineStill 800T 120 film_box_outside](./lowres/00006_000.jpg)](./archive/00006_000.jpg)
+<a href="./archive/00006_000.jpg">
+	<img src="./lowres/00006_000.jpg" alt="CineStill 800T 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for CineStill 800T (ref: d1a6)](./archive/00006_001.jpg)
 
@@ -204,7 +218,9 @@ UUID    : cde1122dafbc47088a11d9ee12b6471a
 Scanned By: dekuNukem
 ```
 
-[![Efiniti UXi super 200 35mm film_box_outside](./lowres/00002_000.jpg)](./archive/00002_000.jpg)
+<a href="./archive/00002_000.jpg">
+	<img src="./lowres/00002_000.jpg" alt="Efiniti UXi super 200 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Efke IR 820 (ref: 43c9)
 ```
@@ -216,7 +232,9 @@ UUID    : 716e410a3823476e9befa704361f43c9
 Scanned By: dekuNukem
 ```
 
-[![Efke IR 820 120 film_box_outside](./lowres/00038_000.jpg)](./archive/00038_000.jpg)
+<a href="./archive/00038_000.jpg">
+	<img src="./lowres/00038_000.jpg" alt="Efke IR 820 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Efke IR 820 (ref: 5e19)](./archive/00038_001.jpg)
 
@@ -230,7 +248,9 @@ UUID    : 7be1cb0047f14034a7386cd7b1843e4f
 Scanned By: benikum
 ```
 
-[![Foma Fomapan 120 film_box_outside](./lowres/00070_000.jpg)](./archive/00070_000.jpg)
+<a href="./archive/00070_000.jpg">
+	<img src="./lowres/00070_000.jpg" alt="Foma Fomapan 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Foma Fomapan (ref: bd71)](./archive/00070_001.jpg)
 
@@ -244,7 +264,9 @@ UUID    : fe02d85cb9294ee2ba64e8543ce65b41
 Scanned By: Yrikonchik
 ```
 
-[![Fujifilm 200 35mm film_box_outside](./lowres/00073_000.jpg)](./archive/00073_000.jpg)
+<a href="./archive/00073_000.jpg">
+	<img src="./lowres/00073_000.jpg" alt="Fujifilm 200 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Fujifilm FUJICOLOR SUPER HR (ref: aaa0)
 ```
@@ -256,7 +278,9 @@ UUID    : 2d27c9a865aa4de19ad8dc0bcdc8aaa0
 Scanned By: dekuNukem
 ```
 
-[![Fujifilm FUJICOLOR SUPER HR 35mm film_box_outside](./lowres/00007_000.jpg)](./archive/00007_000.jpg)
+<a href="./archive/00007_000.jpg">
+	<img src="./lowres/00007_000.jpg" alt="Fujifilm FUJICOLOR SUPER HR 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Fujifilm FUJICOLOR SUPER HR (ref: 57f6)](./archive/00007_001.jpg)
 
@@ -272,7 +296,9 @@ UUID    : c3d9e51d22e241f69133be30d5a00683
 Scanned By: dekuNukem
 ```
 
-[![Fujifilm FUJICOLOR SUPERIA 120 film_box_outside](./lowres/00012_000.jpg)](./archive/00012_000.jpg)
+<a href="./archive/00012_000.jpg">
+	<img src="./lowres/00012_000.jpg" alt="Fujifilm FUJICOLOR SUPERIA 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Fujifilm FUJICOLOR SUPERIA (ref: 118f)](./archive/00012_001.jpg)
 
@@ -286,7 +312,9 @@ UUID    : 5dcdd19ddf654415b7eac69183e7439d
 Scanned By: dekuNukem
 ```
 
-[![Fujifilm Fujichrome Professional 100D 120 film_box_outside](./lowres/00032_000.jpg)](./archive/00032_000.jpg)
+<a href="./archive/00032_000.jpg">
+	<img src="./lowres/00032_000.jpg" alt="Fujifilm Fujichrome Professional 100D 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Fujifilm Fujichrome Professional 100D (ref: c977)](./archive/00032_001.jpg)
 
@@ -302,7 +330,9 @@ UUID    : 27d88b35933b4ede958b5b5b5b42013b
 Scanned By: b0baspace
 ```
 
-[![Fujifilm Fujicolor 100 35mm film_box_outside](./lowres/00040_000.jpg)](./archive/00040_000.jpg)
+<a href="./archive/00040_000.jpg">
+	<img src="./lowres/00040_000.jpg" alt="Fujifilm Fujicolor 100 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Fujifilm Fujicolor NPL 160 (ref: d10b)
 ```
@@ -314,7 +344,9 @@ UUID    : ce40cc432d9e445b987fdd72fd88d10b
 Scanned By: dekuNukem
 ```
 
-[![Fujifilm Fujicolor NPL 160 120 film_box_outside](./lowres/00034_000.jpg)](./archive/00034_000.jpg)
+<a href="./archive/00034_000.jpg">
+	<img src="./lowres/00034_000.jpg" alt="Fujifilm Fujicolor NPL 160 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Fujifilm Fujicolor NPL 160 (ref: 1455)](./archive/00034_001.jpg)
 
@@ -330,7 +362,9 @@ UUID    : 576142521c2f4fe5abc387032bcc5e85
 Scanned By: b0baspace
 ```
 
-[![Fujifilm NPS 35mm film_box_outside](./lowres/00053_000.jpg)](./archive/00053_000.jpg)
+<a href="./archive/00053_000.jpg">
+	<img src="./lowres/00053_000.jpg" alt="Fujifilm NPS 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Fujifilm NPS (ref: 69c4)](./archive/00053_001.jpg)
 
@@ -344,7 +378,9 @@ UUID    : 0d89ecf11f3c46deb52171aa909566e3
 Scanned By: dekuNukem
 ```
 
-[![Fujifilm Pro 400H 120 film_box_outside](./lowres/00022_000.jpg)](./archive/00022_000.jpg)
+<a href="./archive/00022_000.jpg">
+	<img src="./lowres/00022_000.jpg" alt="Fujifilm Pro 400H 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Fujifilm Provia 100F (ref: 356d)
 ```
@@ -356,7 +392,9 @@ UUID    : a3603dbdd8ca49b893c8ce2bc76f356d
 Scanned By: @seklerek
 ```
 
-[![Fujifilm Provia 100F 35mm film_box_outside](./lowres/00055_000.jpg)](./archive/00055_000.jpg)
+<a href="./archive/00055_000.jpg">
+	<img src="./lowres/00055_000.jpg" alt="Fujifilm Provia 100F 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Fujifilm Velvia (ref: 3182)
 ```
@@ -368,7 +406,9 @@ UUID    : 9b9ee1c1c0e94d968674987799d33182
 Scanned By: @ob.skura
 ```
 
-[![Fujifilm Velvia 35mm film_box_outside](./lowres/00044_000.jpg)](./archive/00044_000.jpg)
+<a href="./archive/00044_000.jpg">
+	<img src="./lowres/00044_000.jpg" alt="Fujifilm Velvia 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Fujifilm Velvia (ref: 7e76)](./archive/00044_001.jpg)
 
@@ -384,7 +424,9 @@ UUID    : 0fef128c3b17437eb25d5c4f0520f7fb
 Scanned By: dekuNukem
 ```
 
-[![Fujifilm Velvia 100F 120 film_box_outside](./lowres/00023_000.jpg)](./archive/00023_000.jpg)
+<a href="./archive/00023_000.jpg">
+	<img src="./lowres/00023_000.jpg" alt="Fujifilm Velvia 100F 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Fujifilm Velvia 100F (ref: 32d4)
 ```
@@ -396,7 +438,9 @@ UUID    : ce5c1d786286427ba5633091b06432d4
 Scanned By: @seklerek
 ```
 
-[![Fujifilm Velvia 100F 35mm film_box_outside](./lowres/00056_000.jpg)](./archive/00056_000.jpg)
+<a href="./archive/00056_000.jpg">
+	<img src="./lowres/00056_000.jpg" alt="Fujifilm Velvia 100F 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### GAF Color Slide Film (ref: dea6)
 ```
@@ -408,7 +452,9 @@ UUID    : c426ea17398c4c549c6a2720103adea6
 Scanned By: b0baspace
 ```
 
-[![GAF Color Slide Film 126 film_box_outside](./lowres/00054_000.jpg)](./archive/00054_000.jpg)
+<a href="./archive/00054_000.jpg">
+	<img src="./lowres/00054_000.jpg" alt="GAF Color Slide Film 126 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for GAF Color Slide Film (ref: 2332)](./archive/00054_001.jpg)
 
@@ -430,7 +476,9 @@ UUID    : 0b11ba38c9a34f58a2f13d696b05637f
 Scanned By: dekuNukem
 ```
 
-[![HARMAN PHOENIX 120 film_box_outside](./lowres/00004_000.jpg)](./archive/00004_000.jpg)
+<a href="./archive/00004_000.jpg">
+	<img src="./lowres/00004_000.jpg" alt="HARMAN PHOENIX 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Ilford Delta (ref: eb8d)
 ```
@@ -442,7 +490,9 @@ UUID    : e39c5eca4e3e4e5badfa00ee512deb8d
 Scanned By: @ob.skura
 ```
 
-[![Ilford Delta 120 film_box_outside](./lowres/00048_000.jpg)](./archive/00048_000.jpg)
+<a href="./archive/00048_000.jpg">
+	<img src="./lowres/00048_000.jpg" alt="Ilford Delta 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Ilford Delta (ref: 01d0)](./archive/00048_001.jpg)
 
@@ -456,7 +506,9 @@ UUID    : 36151f6b7cc045c2b43d7f5cbee41a5d
 Scanned By: dekuNukem
 ```
 
-[![Ilford HP5 Plus 120 film_box_outside](./lowres/00000_000.jpg)](./archive/00000_000.jpg)
+<a href="./archive/00000_000.jpg">
+	<img src="./lowres/00000_000.jpg" alt="Ilford HP5 Plus 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Ilford HP5 Plus (ref: 5f25)](./archive/00000_001.jpg)
 
@@ -470,7 +522,9 @@ UUID    : ddf9b76e633f43718144af7dcb89efad
 Scanned By: dekuNukem
 ```
 
-[![Ilford HP5 Plus 120 film_box_outside](./lowres/00016_000.jpg)](./archive/00016_000.jpg)
+<a href="./archive/00016_000.jpg">
+	<img src="./lowres/00016_000.jpg" alt="Ilford HP5 Plus 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Ilford HP5 Plus (ref: 8dda)](./archive/00016_001.jpg)
 
@@ -484,7 +538,9 @@ UUID    : 7856b5442362453caa67628c93be6057
 Scanned By: dekuNukem
 ```
 
-[![Ilford SFX 200 120 film_box_outside](./lowres/00009_000.jpg)](./archive/00009_000.jpg)
+<a href="./archive/00009_000.jpg">
+	<img src="./lowres/00009_000.jpg" alt="Ilford SFX 200 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Ilford SFX 200 (ref: 422d)](./archive/00009_001.jpg)
 
@@ -498,7 +554,9 @@ UUID    : b53e5c167866448d812a4dc8e85967d3
 Scanned By: dekuNukem
 ```
 
-[![Jessops Diamond Everyday APS film_box_outside](./lowres/00033_000.jpg)](./archive/00033_000.jpg)
+<a href="./archive/00033_000.jpg">
+	<img src="./lowres/00033_000.jpg" alt="Jessops Diamond Everyday APS film_box_outside" loading="lazy" />
+</a>
 
 #### Kentmere PAN (ref: 827e)
 ```
@@ -510,7 +568,9 @@ UUID    : d2cf9753f6fd49a78404c72d848a827e
 Scanned By: dekuNukem
 ```
 
-[![Kentmere PAN 35mm film_box_outside](./lowres/00015_000.jpg)](./archive/00015_000.jpg)
+<a href="./archive/00015_000.jpg">
+	<img src="./lowres/00015_000.jpg" alt="Kentmere PAN 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Kentmere PAN (ref: 9f55)](./archive/00015_001.jpg)
 
@@ -524,7 +584,9 @@ UUID    : e876f866f1e9430494356ad098c7d223
 Scanned By: dekuNukem
 ```
 
-[![Kentmere PAN 35mm film_box_outside](./lowres/00058_000.jpg)](./archive/00058_000.jpg)
+<a href="./archive/00058_000.jpg">
+	<img src="./lowres/00058_000.jpg" alt="Kentmere PAN 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Kentmere PAN (ref: 6587)](./archive/00058_001.jpg)
 
@@ -538,7 +600,9 @@ UUID    : 1dc3d9dbb8bb42b4acfbfbe0737a4b88
 Scanned By: dekuNukem
 ```
 
-[![Klick APS Film APS film_box_outside](./lowres/00063_000.jpg)](./archive/00063_000.jpg)
+<a href="./archive/00063_000.jpg">
+	<img src="./lowres/00063_000.jpg" alt="Klick APS Film APS film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Klick APS Film (ref: ed86)](./archive/00063_001.jpg)
 
@@ -552,7 +616,9 @@ UUID    : 2276628aa2794442ae81221329fc44d7
 Scanned By: dekuNukem
 ```
 
-[![Klick XD200 110 film_box_outside](./lowres/00062_000.jpg)](./archive/00062_000.jpg)
+<a href="./archive/00062_000.jpg">
+	<img src="./lowres/00062_000.jpg" alt="Klick XD200 110 film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Advantix Ultra (ref: 566b)
 ```
@@ -564,7 +630,9 @@ UUID    : 041622f239024ffb8b75c367619a566b
 Scanned By: dekuNukem
 ```
 
-[![Kodak Advantix Ultra APS film_box_outside](./lowres/00066_000.jpg)](./archive/00066_000.jpg)
+<a href="./archive/00066_000.jpg">
+	<img src="./lowres/00066_000.jpg" alt="Kodak Advantix Ultra APS film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Ektachrome (ref: ce7f)
 ```
@@ -576,7 +644,9 @@ UUID    : ec7cf78858fc48c59e5a0875ec74ce7f
 Scanned By: dekuNukem
 ```
 
-[![Kodak Ektachrome 120 film_box_outside](./lowres/00017_000.jpg)](./archive/00017_000.jpg)
+<a href="./archive/00017_000.jpg">
+	<img src="./lowres/00017_000.jpg" alt="Kodak Ektachrome 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Ektachrome (ref: 07c0)
 ```
@@ -588,7 +658,9 @@ UUID    : 8131d8c6fbf14016be9c17a2586b07c0
 Scanned By: dekuNukem
 ```
 
-[![Kodak Ektachrome 110 film_box_outside](./lowres/00025_000.jpg)](./archive/00025_000.jpg)
+<a href="./archive/00025_000.jpg">
+	<img src="./lowres/00025_000.jpg" alt="Kodak Ektachrome 110 film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Ektachrome (ref: ec3d)
 ```
@@ -600,7 +672,9 @@ UUID    : 9702189f65de43c59fce151094a7ec3d
 Scanned By: @ob.skura
 ```
 
-[![Kodak Ektachrome 35mm film_box_outside](./lowres/00045_000.jpg)](./archive/00045_000.jpg)
+<a href="./archive/00045_000.jpg">
+	<img src="./lowres/00045_000.jpg" alt="Kodak Ektachrome 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Kodak Ektachrome (ref: 86cd)](./archive/00045_001.jpg)
 
@@ -616,7 +690,9 @@ UUID    : 7d8346073bbe4d6a84e57cc2bb28b21e
 Scanned By: b0baspace
 ```
 
-[![Kodak Ektachrome 35mm film_box_outside](./lowres/00052_000.jpg)](./archive/00052_000.jpg)
+<a href="./archive/00052_000.jpg">
+	<img src="./lowres/00052_000.jpg" alt="Kodak Ektachrome 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Kodak Ektachrome (ref: 8943)](./archive/00052_001.jpg)
 
@@ -632,7 +708,9 @@ UUID    : 7456456d09c844c8ab046abd9c17c3f8
 Scanned By: dekuNukem
 ```
 
-[![Kodak Ektacolor Pro Gold 220 film_box_outside](./lowres/00027_000.jpg)](./archive/00027_000.jpg)
+<a href="./archive/00027_000.jpg">
+	<img src="./lowres/00027_000.jpg" alt="Kodak Ektacolor Pro Gold 220 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Kodak Ektacolor Pro Gold (ref: a6ff)](./archive/00027_001.jpg)
 
@@ -650,7 +728,9 @@ UUID    : e0b3ec957ade47a99d5cd5abe2a4523c
 Scanned By: @ob.skura
 ```
 
-[![Kodak Elite Chrome 35mm film_box_outside](./lowres/00042_000.jpg)](./archive/00042_000.jpg)
+<a href="./archive/00042_000.jpg">
+	<img src="./lowres/00042_000.jpg" alt="Kodak Elite Chrome 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Gold (ref: 933f)
 ```
@@ -662,7 +742,9 @@ UUID    : e8aefc10fa0d43cebbac73bdcf10933f
 Scanned By: dekuNukem
 ```
 
-[![Kodak Gold 35mm film_box_outside](./lowres/00021_000.jpg)](./archive/00021_000.jpg)
+<a href="./archive/00021_000.jpg">
+	<img src="./lowres/00021_000.jpg" alt="Kodak Gold 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Gold (ref: f368)
 ```
@@ -674,7 +756,9 @@ UUID    : 78bfeed667154d819902ec92d7dcf368
 Scanned By: dekuNukem
 ```
 
-[![Kodak Gold 110 film_box_outside](./lowres/00068_000.jpg)](./archive/00068_000.jpg)
+<a href="./archive/00068_000.jpg">
+	<img src="./lowres/00068_000.jpg" alt="Kodak Gold 110 film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Kodachrome (ref: 3145)
 ```
@@ -686,7 +770,9 @@ UUID    : 68c945b76fc14ab699b944a3c7b93145
 Scanned By: dekuNukem
 ```
 
-[![Kodak Kodachrome 110 film_box_outside](./lowres/00026_000.jpg)](./archive/00026_000.jpg)
+<a href="./archive/00026_000.jpg">
+	<img src="./lowres/00026_000.jpg" alt="Kodak Kodachrome 110 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **PROCESSING ENVELOPE** for Kodak Kodachrome (ref: 9bdf)](./archive/00026_001.jpg)
 
@@ -702,7 +788,9 @@ UUID    : 483191da2aa742bba3343cbe9f296477
 Scanned By: dekuNukem
 ```
 
-[![Kodak Kodachrome 35mm film_box_outside](./lowres/00035_000.jpg)](./archive/00035_000.jpg)
+<a href="./archive/00035_000.jpg">
+	<img src="./lowres/00035_000.jpg" alt="Kodak Kodachrome 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Kodak Kodachrome (ref: 83b8)](./archive/00035_001.jpg)
 
@@ -722,7 +810,9 @@ UUID    : dc9c151b87de48339e564e6692663206
 Scanned By: dekuNukem
 ```
 
-[![Kodak Kodachrome 35mm film_box_outside](./lowres/00060_000.jpg)](./archive/00060_000.jpg)
+<a href="./archive/00060_000.jpg">
+	<img src="./lowres/00060_000.jpg" alt="Kodak Kodachrome 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Kodacolor-X (ref: 5302)
 ```
@@ -734,7 +824,9 @@ UUID    : 5a3d2ba8ff7649c9b3450d7069445302
 Scanned By: dekuNukem
 ```
 
-[![Kodak Kodacolor-X 126 film_box_outside](./lowres/00024_000.jpg)](./archive/00024_000.jpg)
+<a href="./archive/00024_000.jpg">
+	<img src="./lowres/00024_000.jpg" alt="Kodak Kodacolor-X 126 film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Kodacolor-X (ref: a4b1)
 ```
@@ -746,7 +838,9 @@ UUID    : 01bfcffd1db54d6eadefbc1442f7a4b1
 Scanned By: dekuNukem
 ```
 
-[![Kodak Kodacolor-X 120 film_box_outside](./lowres/00064_000.jpg)](./archive/00064_000.jpg)
+<a href="./archive/00064_000.jpg">
+	<img src="./lowres/00064_000.jpg" alt="Kodak Kodacolor-X 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Kodak Kodacolor-X (ref: 97fa)](./archive/00064_001.jpg)
 
@@ -762,7 +856,9 @@ UUID    : 9a43d0c373354e1989ea7bb7a43db3b1
 Scanned By: dekuNukem
 ```
 
-[![Kodak TMAX 120 film_box_outside](./lowres/00069_000.jpg)](./archive/00069_000.jpg)
+<a href="./archive/00069_000.jpg">
+	<img src="./lowres/00069_000.jpg" alt="Kodak TMAX 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Technical Pan 6415 (ref: 03be)
 ```
@@ -774,7 +870,9 @@ UUID    : 3a03860d64d2400caee97955197703be
 Scanned By: dekuNukem
 ```
 
-[![Kodak Technical Pan 6415 120 film_box_outside](./lowres/00037_000.jpg)](./archive/00037_000.jpg)
+<a href="./archive/00037_000.jpg">
+	<img src="./lowres/00037_000.jpg" alt="Kodak Technical Pan 6415 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Kodak Technical Pan 6415 (ref: 1bc8)](./archive/00037_001.jpg)
 
@@ -790,7 +888,9 @@ UUID    : f7f99b9d46a4491c9cbfda4f030f88c5
 Scanned By: dekuNukem
 ```
 
-[![Kodak Tri-X 120 film_box_outside](./lowres/00028_000.jpg)](./archive/00028_000.jpg)
+<a href="./archive/00028_000.jpg">
+	<img src="./lowres/00028_000.jpg" alt="Kodak Tri-X 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Ultra (ref: 69a1)
 ```
@@ -802,7 +902,9 @@ UUID    : 77dfbdf80e3a4950b40c7ea8c1e369a1
 Scanned By: @ob.skura
 ```
 
-[![Kodak Ultra 35mm film_box_outside](./lowres/00043_000.jpg)](./archive/00043_000.jpg)
+<a href="./archive/00043_000.jpg">
+	<img src="./lowres/00043_000.jpg" alt="Kodak Ultra 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Kodak Verichrome Pan (ref: 0195)
 ```
@@ -814,7 +916,9 @@ UUID    : 75c7c232d44949c3b1d766b0d2580195
 Scanned By: b0baspace
 ```
 
-[![Kodak Verichrome Pan 620 film_box_outside](./lowres/00041_000.jpg)](./archive/00041_000.jpg)
+<a href="./archive/00041_000.jpg">
+	<img src="./lowres/00041_000.jpg" alt="Kodak Verichrome Pan 620 film_box_outside" loading="lazy" />
+</a>
 
 #### Konica Infrared 750nm (ref: 2d93)
 ```
@@ -826,7 +930,9 @@ UUID    : 63b2857f2df549878446cc1963362d93
 Scanned By: dekuNukem
 ```
 
-[![Konica Infrared 750nm 120 film_box_outside](./lowres/00036_000.jpg)](./archive/00036_000.jpg)
+<a href="./archive/00036_000.jpg">
+	<img src="./lowres/00036_000.jpg" alt="Konica Infrared 750nm 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Konica Infrared 750nm (ref: e696)
 ```
@@ -838,7 +944,9 @@ UUID    : 79a0275aee8e43e895b5794a8538e696
 Scanned By: dekuNukem
 ```
 
-[![Konica Infrared 750nm 120 film_box_outside](./lowres/00039_000.jpg)](./archive/00039_000.jpg)
+<a href="./archive/00039_000.jpg">
+	<img src="./lowres/00039_000.jpg" alt="Konica Infrared 750nm 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Konica Infrared 750nm (ref: f1ad)](./archive/00039_001.jpg)
 
@@ -852,7 +960,9 @@ UUID    : 44bd7d4688e04d19a958d961c2abc7cf
 Scanned By: dekuNukem
 ```
 
-[![Lloyds Pharmacy APS Film APS film_box_outside](./lowres/00067_000.jpg)](./archive/00067_000.jpg)
+<a href="./archive/00067_000.jpg">
+	<img src="./lowres/00067_000.jpg" alt="Lloyds Pharmacy APS Film APS film_box_outside" loading="lazy" />
+</a>
 
 #### Lloyds Pharmacy Colour Film (ref: 77d9)
 ```
@@ -864,7 +974,9 @@ UUID    : c58dda071d1741fda90e20b4252277d9
 Scanned By: dekuNukem
 ```
 
-[![Lloyds Pharmacy Colour Film 35mm film_box_outside](./lowres/00013_000.jpg)](./archive/00013_000.jpg)
+<a href="./archive/00013_000.jpg">
+	<img src="./lowres/00013_000.jpg" alt="Lloyds Pharmacy Colour Film 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Lomography Lomochrome Turquoise (ref: 0d90)
 ```
@@ -876,7 +988,9 @@ UUID    : 99643a4fc27b4ff298e834fc72970d90
 Scanned By: dekuNukem
 ```
 
-[![Lomography Lomochrome Turquoise 120 film_box_outside](./lowres/00008_000.jpg)](./archive/00008_000.jpg)
+<a href="./archive/00008_000.jpg">
+	<img src="./lowres/00008_000.jpg" alt="Lomography Lomochrome Turquoise 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Lomography Lomochrome Turquoise (ref: 1ca2)](./archive/00008_001.jpg)
 
@@ -890,7 +1004,9 @@ UUID    : 311d896d68b74b1193afcfa129c5e054
 Scanned By: dekuNukem
 ```
 
-[![Polaroid 665 Pack Film film_box_outside](./lowres/00018_000.jpg)](./archive/00018_000.jpg)
+<a href="./archive/00018_000.jpg">
+	<img src="./lowres/00018_000.jpg" alt="Polaroid 665 Pack Film film_box_outside" loading="lazy" />
+</a>
 
 #### Polaroid 669 (ref: 3566)
 ```
@@ -902,7 +1018,9 @@ UUID    : bb62de3a22c04f699c780aeae7c83566
 Scanned By: dekuNukem
 ```
 
-[![Polaroid 669 Pack Film film_box_outside](./lowres/00020_000.jpg)](./archive/00020_000.jpg)
+<a href="./archive/00020_000.jpg">
+	<img src="./lowres/00020_000.jpg" alt="Polaroid 669 Pack Film film_box_outside" loading="lazy" />
+</a>
 
 #### Polaroid GridFilm (ref: 8deb)
 ```
@@ -914,10 +1032,14 @@ UUID    : 4f1aabf29f724c9ea3b2bee414b08deb
 Scanned By: dekuNukem
 ```
 
-[![Polaroid GridFilm Integral Film film_box_outside](./lowres/00031_000.jpg)](./archive/00031_000.jpg)
+<a href="./archive/00031_000.jpg">
+	<img src="./lowres/00031_000.jpg" alt="Polaroid GridFilm Integral Film film_box_outside" loading="lazy" />
+</a>
 
 
-[![Polaroid GridFilm Integral Film film_box_outside](./lowres/00031_001.jpg)](./archive/00031_001.jpg)
+<a href="./archive/00031_001.jpg">
+	<img src="./lowres/00031_001.jpg" alt="Polaroid GridFilm Integral Film film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Polaroid GridFilm (ref: 0077)](./archive/00031_002.jpg)
 
@@ -933,7 +1055,9 @@ UUID    : 8236180d686f4e9ca4aa8e6fc397df66
 Scanned By: dekuNukem
 ```
 
-[![Polaroid PolaBlue 35mm film_box_outside](./lowres/00019_000.jpg)](./archive/00019_000.jpg)
+<a href="./archive/00019_000.jpg">
+	<img src="./lowres/00019_000.jpg" alt="Polaroid PolaBlue 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Polaroid PolaChrome (ref: 3b60)
 ```
@@ -945,7 +1069,9 @@ UUID    : b0041b1e44a64f6591d49e918e033b60
 Scanned By: dekuNukem
 ```
 
-[![Polaroid PolaChrome 35mm film_box_outside](./lowres/00029_000.jpg)](./archive/00029_000.jpg)
+<a href="./archive/00029_000.jpg">
+	<img src="./lowres/00029_000.jpg" alt="Polaroid PolaChrome 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Porst Color N21 (ref: 494a)
 ```
@@ -957,7 +1083,9 @@ UUID    : e08418889f714c9dbda0858718e0494a
 Scanned By: @ob.skura
 ```
 
-[![Porst Color N21 35mm film_box_outside](./lowres/00046_000.jpg)](./archive/00046_000.jpg)
+<a href="./archive/00046_000.jpg">
+	<img src="./lowres/00046_000.jpg" alt="Porst Color N21 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **LEAFLET** for Porst Color N21 (ref: 2359)](./archive/00046_001.jpg)
 
@@ -971,7 +1099,9 @@ UUID    : b7bb7d65979543d0a8e5c9179d734f54
 Scanned By: dekuNukem
 ```
 
-[![Rollei Infrared 120 film_box_outside](./lowres/00030_000.jpg)](./archive/00030_000.jpg)
+<a href="./archive/00030_000.jpg">
+	<img src="./lowres/00030_000.jpg" alt="Rollei Infrared 120 film_box_outside" loading="lazy" />
+</a>
 
 #### Rollei Infrared (ref: eae2)
 ```
@@ -983,7 +1113,9 @@ UUID    : 9ef642a09d294cbfad7e040a701deae2
 Scanned By: @ob.skura
 ```
 
-[![Rollei Infrared 35mm film_box_outside](./lowres/00047_000.jpg)](./archive/00047_000.jpg)
+<a href="./archive/00047_000.jpg">
+	<img src="./lowres/00047_000.jpg" alt="Rollei Infrared 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Rollei Infrared (ref: e71e)](./archive/00047_001.jpg)
 
@@ -997,7 +1129,9 @@ UUID    : fb2ccfebcf2f4a17afe00acaaea5e6c0
 Scanned By: dekuNukem
 ```
 
-[![Rollei Retro 80S 120 film_box_outside](./lowres/00005_000.jpg)](./archive/00005_000.jpg)
+<a href="./archive/00005_000.jpg">
+	<img src="./lowres/00005_000.jpg" alt="Rollei Retro 80S 120 film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Rollei Retro 80S (ref: 200c)](./archive/00005_001.jpg)
 
@@ -1011,7 +1145,9 @@ UUID    : f22d3e1e2f70453f87aea4b67db3ee8f
 Scanned By: benikum
 ```
 
-[![Rollei SUPERPAN 35mm film_box_outside](./lowres/00071_000.jpg)](./archive/00071_000.jpg)
+<a href="./archive/00071_000.jpg">
+	<img src="./lowres/00071_000.jpg" alt="Rollei SUPERPAN 35mm film_box_outside" loading="lazy" />
+</a>
 
 [Click me for **BOX INSIDE** for Rollei SUPERPAN (ref: a6dd)](./archive/00071_001.jpg)
 
@@ -1025,7 +1161,9 @@ UUID    : b09413c4c1f44fceaa31ea8e50bf7670
 Scanned By: benikum
 ```
 
-[![Rossmann Jahreszeiten Pack 35mm film_box_outside](./lowres/00072_000.jpg)](./archive/00072_000.jpg)
+<a href="./archive/00072_000.jpg">
+	<img src="./lowres/00072_000.jpg" alt="Rossmann Jahreszeiten Pack 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Shanghai GP3 (ref: 52aa)
 ```
@@ -1037,7 +1175,9 @@ UUID    : 0e16f7ae50164c658acd22b8d62e52aa
 Scanned By: @ob.skura
 ```
 
-[![Shanghai GP3 127 film_box_outside](./lowres/00050_000.jpg)](./archive/00050_000.jpg)
+<a href="./archive/00050_000.jpg">
+	<img src="./lowres/00050_000.jpg" alt="Shanghai GP3 127 film_box_outside" loading="lazy" />
+</a>
 
 #### Three Film Rolls 5207 (ref: 0292)
 ```
@@ -1049,7 +1189,9 @@ UUID    : 4de0f5e76dd748c488fa81be23340292
 Scanned By: dekuNukem
 ```
 
-[![Three Film Rolls 5207 35mm film_box_outside](./lowres/00059_000.jpg)](./archive/00059_000.jpg)
+<a href="./archive/00059_000.jpg">
+	<img src="./lowres/00059_000.jpg" alt="Three Film Rolls 5207 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### Wolfen NC500 (ref: 91c1)
 ```
@@ -1061,7 +1203,9 @@ UUID    : 6e3408d7e97247e380ea52077a7491c1
 Scanned By: @ob.skura
 ```
 
-[![Wolfen NC500 35mm film_box_outside](./lowres/00049_000.jpg)](./archive/00049_000.jpg)
+<a href="./archive/00049_000.jpg">
+	<img src="./lowres/00049_000.jpg" alt="Wolfen NC500 35mm film_box_outside" loading="lazy" />
+</a>
 
 #### York Photo Labs DXG 200 (ref: 4bf8)
 ```
@@ -1073,7 +1217,9 @@ UUID    : 46037fb6c55244b6ae47c55d0e454bf8
 Scanned By: b0baspace
 ```
 
-[![York Photo Labs DXG 200 35mm film_box_outside](./lowres/00051_000.jpg)](./archive/00051_000.jpg)
+<a href="./archive/00051_000.jpg">
+	<img src="./lowres/00051_000.jpg" alt="York Photo Labs DXG 200 35mm film_box_outside" loading="lazy" />
+</a>
 
 
 ## Want to contribute?

--- a/film_packaging/shared.py
+++ b/film_packaging/shared.py
@@ -163,11 +163,11 @@ def make_filename_only(item_dict):
 
 def make_filename_full_path(item_dict):
     new_filename = make_filename_only(item_dict)
-    return os.path.join(archive_dir_path, new_filename)
+    return os.path.join(archive_dir_path, new_filename).replace('\\', '/')
 
 def make_lowres_full_path(item_dict):
     new_filename = make_filename_only(item_dict)
-    return os.path.join(lowres_dir_path, new_filename)
+    return os.path.join(lowres_dir_path, new_filename).replace('\\', '/')
 
 def convert_keys_to_int(db_dict):
     for this_entry in db_dict:

--- a/film_packaging/update_page.py
+++ b/film_packaging/update_page.py
@@ -5,6 +5,10 @@ import time
 from shared import *
 import operator
 
+# Enforce UTF-8 for consistency across terminals
+sys.stdout.reconfigure(encoding='utf-8')
+
+
 def make_description_string(this_entry, keyname):
     if keyname not in this_entry:
         raise ValueError()

--- a/film_packaging/update_page.py
+++ b/film_packaging/update_page.py
@@ -17,6 +17,12 @@ def make_alt_text(this_entry):
 def make_subtitle(this_entry):
     return f"{this_entry[ITEM_BRAND_KEY]} {this_entry[ITEM_PRODUCT_NAME_KEY]} (ref: {this_entry[ITEM_UUID_KEY][-4:]})"
 
+def make_lazy_load_image_link(this_lowres_path, this_image_path, this_entry):
+    output = f"\n<a href=\"{this_image_path}\">"
+    output += f"\n\t<img src=\"{this_lowres_path}\" alt=\"{make_alt_text(this_entry)}\" loading=\"lazy\" />"
+    output += f"\n</a>\n"
+    return output
+
 placeholder = '$%'
 def make_section(text):
     text = text.lstrip("#").replace('\r', '').replace('\n', '').strip()
@@ -112,7 +118,7 @@ for item in result:
         description += make_description_string(item, ITEM_UUID_KEY)
         description += make_description_string(item, ITEM_AUTHOR_KEY)
         description += "```\n"
-        description += f"\n[![{make_alt_text(item)}]({lowres_path})]({image_path})\n"
+        description += make_lazy_load_image_link(lowres_path, image_path, item)
     elif 'inside' in item[ITEM_TYPE_KEY].lower():
         description += f"[Click me for **BOX INSIDE** for {make_subtitle(item)}]({image_path})\n"
     elif 'leaflet' in item[ITEM_TYPE_KEY].lower():
@@ -120,7 +126,7 @@ for item in result:
     elif 'envelope' in item[ITEM_TYPE_KEY].lower():
         description += f"[Click me for **PROCESSING ENVELOPE** for {make_subtitle(item)}]({image_path})\n"
     else:
-        description += f"\n[![{make_alt_text(item)}]({lowres_path})]({image_path})\n"
+        description += make_lazy_load_image_link(lowres_path, image_path, item)
 
     print(description)
     


### PR DESCRIPTION
This PR changes the images on the brand listing page to take advantage of the [`loading="lazy"` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading), which will wait to load images until they enter (or are about to enter) the browser viewport. The `loading="lazy"` attribute value [has mainstream browser support](https://caniuse.com/loading-lazy-attr) as of 2023, so virtually all visitors should see this improvement.

It's worth noting that by the time you scroll to the end of the page, all images will have been loaded. As far as I know, there's no simple way around that without writing custom HTML/JS/CSS.

I am submitting this because [someone on reddit was particularly offended](https://www.reddit.com/r/AnalogCommunity/comments/1l3xurg/ideas_on_what_to_do_with_film_boxes/mw54ume/) by the page loading all images at once. This is probably less of an issue now that it uses low-res images for the thumbnails, but may still improve the page performance on slower or mobile connections and phones.

You can see a live version of this branch here: https://kyleratti.github.io/Film-Packaging/